### PR TITLE
Feature: Whitelist Hostnames

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,12 @@ module.exports = {
         // Fathom server URL. Defaults to `cdn.usefathom.com`
         trackingUrl: 'your-fathom-instance.com',
         // Unique site id
-        siteId: 'FATHOM_SITE_ID'
+        siteId: 'FATHOM_SITE_ID',
+        // Exclude stats for specific hostnames
+        excludeHostnames: [
+          'localhost',
+          'othersite.com'
+        ]
       }
     }
   ]

--- a/README.md
+++ b/README.md
@@ -30,10 +30,9 @@ module.exports = {
         trackingUrl: 'your-fathom-instance.com',
         // Unique site id
         siteId: 'FATHOM_SITE_ID',
-        // Domain blacklist
-        excludeHostnames: [
-          'localhost',
-          'othersite.com'
+        // Domain whitelist
+        whitelistHostnames: [
+          'yoursite.com'
         ]
       }
     }
@@ -45,11 +44,11 @@ _By default, this plugin only generates output when run in production mode. To t
 
 ## Options
 
-| Option             | Explanation                                                                                      |
-| ------------------ | ------------------------------------------------------------------------------------------------ |
-| `trackingUrl`      | Your Fathom instance URL (optional; only necessary if self-hosting Fathom)                       |
-| `siteId`           | Unique site id (required when using the hosted version of Fathom or self-hosting Fathom v1.1.0+) |
-| `excludeHostnames` | List of hostnames you wish to prevent tracking for (optional)                                    |
+| Option               | Explanation                                                                                                  |
+| -------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `trackingUrl`        | Your Fathom instance URL (optional; only necessary if self-hosting Fathom)                                   |
+| `siteId`             | Unique site id (required when using the hosted version of Fathom or self-hosting Fathom v1.1.0+)             |
+| `whitelistHostnames` | List of hostnames to enable tracking for (optional; if not provided tracking will be enabled on all domains) |
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ module.exports = {
         trackingUrl: 'your-fathom-instance.com',
         // Unique site id
         siteId: 'FATHOM_SITE_ID',
-        // Exclude stats for specific hostnames
+        // Domain blacklist
         excludeHostnames: [
           'localhost',
           'othersite.com'
@@ -45,10 +45,11 @@ _By default, this plugin only generates output when run in production mode. To t
 
 ## Options
 
-| Option        | Explanation                                                                                      |
-| ------------- | ------------------------------------------------------------------------------------------------ |
-| `trackingUrl` | Your Fathom instance URL (optional; only necessary if self-hosting Fathom)                       |
-| `siteId`      | Unique site id (required when using the hosted version of Fathom or self-hosting Fathom v1.1.0+) |
+| Option             | Explanation                                                                                      |
+| ------------------ | ------------------------------------------------------------------------------------------------ |
+| `trackingUrl`      | Your Fathom instance URL (optional; only necessary if self-hosting Fathom)                       |
+| `siteId`           | Unique site id (required when using the hosted version of Fathom or self-hosting Fathom v1.1.0+) |
+| `excludeHostnames` | List of hostnames you wish to prevent tracking for (optional)                                    |
 
 ## License
 

--- a/__tests__/gatsby-browser.test.js
+++ b/__tests__/gatsby-browser.test.js
@@ -3,7 +3,7 @@ import { onRouteUpdate } from '../src/gatsby-browser'
 describe('onRouteUpdate', () => {
   const location = { hostname: 'localhost' }
   const pluginOptions = {
-    excludeHostnames: []
+    whitelistHostnames: []
   }
 
   const OLD_NODE_ENV = process.env.NODE_ENV
@@ -56,12 +56,12 @@ describe('onRouteUpdate', () => {
     })
   })
 
-  describe('when hostname is excluded', () => {
+  describe('when hostname is not whitelisted', () => {
     test('should not track page view', () => {
       onRouteUpdate(
-        { location },
+        { location: { hostname: 'localghost' } },
         {
-          excludeHostnames: ['localhost']
+          whitelistHostnames: ['localhost']
         }
       )
 

--- a/__tests__/gatsby-browser.test.js
+++ b/__tests__/gatsby-browser.test.js
@@ -1,0 +1,71 @@
+import { onRouteUpdate } from '../src/gatsby-browser'
+
+describe('onRouteUpdate', () => {
+  const location = { hostname: 'localhost' }
+  const pluginOptions = {
+    excludeHostnames: []
+  }
+
+  const OLD_NODE_ENV = process.env.NODE_ENV
+  const fathomMock = jest.fn()
+
+  beforeEach(() => {
+    jest.resetModules()
+    process.env.NODE_ENV = 'production'
+    global.fathom = fathomMock
+  })
+
+  afterEach(() => {
+    process.env.NODE_ENV = OLD_NODE_ENV
+  })
+
+  test('should track page view', () => {
+    onRouteUpdate({ location }, pluginOptions)
+    expect(fathomMock).toHaveBeenCalledWith('trackPageview')
+  })
+
+  describe('when not running in a production environment', () => {
+    beforeEach(() => {
+      process.env.NODE_ENV = 'development'
+    })
+
+    afterEach(() => {
+      process.env.NODE_ENV = 'production'
+    })
+
+    test('should not track page view', () => {
+      onRouteUpdate({ location }, pluginOptions)
+
+      expect(fathomMock).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('when fathom library is undefined', () => {
+    beforeEach(() => {
+      global.fathom = undefined
+    })
+
+    afterEach(() => {
+      global.fathom = fathomMock
+    })
+
+    test('should not track page view', () => {
+      onRouteUpdate({ location }, pluginOptions)
+
+      expect(fathomMock).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('when hostname is excluded', () => {
+    test('should not track page view', () => {
+      onRouteUpdate(
+        { location },
+        {
+          excludeHostnames: ['localhost']
+        }
+      )
+
+      expect(fathomMock).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/__tests__/utils.test.js
+++ b/__tests__/utils.test.js
@@ -1,4 +1,4 @@
-import { createTrackingSnippet, isExcludedHostname } from '../src/utils'
+import { createTrackingSnippet, isWhitelistedHostname } from '../src/utils'
 
 describe('createTrackingSnippet', () => {
   test('setting the tracking URL', () => {
@@ -45,20 +45,25 @@ describe('createTrackingSnippet', () => {
   })
 })
 
-describe('isExcludedHostname', () => {
-  test('ensuring excluded hostnames is an array', () => {
+describe('isWhitelistedHostname', () => {
+  test('ensuring whitelist is an array', () => {
     expect(function() {
-      isExcludedHostname({})
+      isWhitelistedHostname({})
     }).toThrow()
   })
 
-  test('when hostname is excluded', () => {
-    const isExcluded = isExcludedHostname(['localhost'], 'localhost')
-    expect(isExcluded).toBe(true)
+  test('when whitelist is empty', () => {
+    const isWhitelisted = isWhitelistedHostname([], 'localhost')
+    expect(isWhitelisted).toBe(true)
   })
 
-  test('when hostname is not excluded', () => {
-    const isExcluded = isExcludedHostname(['localhost'], 'localghost')
-    expect(isExcluded).toBe(false)
+  test('when hostname is whitelisted', () => {
+    const isWhitelisted = isWhitelistedHostname(['localhost'], 'localhost')
+    expect(isWhitelisted).toBe(true)
+  })
+
+  test('when hostname is not whitelisted', () => {
+    const isWhitelisted = isWhitelistedHostname(['localhost'], 'localghost')
+    expect(isWhitelisted).toBe(false)
   })
 })

--- a/__tests__/utils.test.js
+++ b/__tests__/utils.test.js
@@ -1,44 +1,64 @@
-import { createTrackingSnippet } from '../src/utils'
+import { createTrackingSnippet, isExcludedHostname } from '../src/utils'
 
-test('setting the tracking URL', () => {
-  const html = createTrackingSnippet({
-    trackingUrl: 'alexlafroscia.com'
-  })
-
-  expect(html).toContain('//alexlafroscia.com/tracker.js')
-})
-
-describe('when the tracking URL is not provided', () => {
-  test('defaulting to the CDN URL', () => {
-    const html = createTrackingSnippet({
-      siteId: 'foo-bar'
-    })
-
-    expect(html).toContain('//cdn.usefathom.com/tracker.js')
-  })
-
-  test('ensuring that a tracking ID is provided', () => {
-    expect(function() {
-      createTrackingSnippet({})
-    }).toThrow()
-  })
-})
-
-describe('setting the site ID', () => {
-  test('when the ID is not provided', () => {
+describe('createTrackingSnippet', () => {
+  test('setting the tracking URL', () => {
     const html = createTrackingSnippet({
       trackingUrl: 'alexlafroscia.com'
     })
 
-    expect(html).not.toContain("fathom('set', 'siteId'")
+    expect(html).toContain('//alexlafroscia.com/tracker.js')
   })
 
-  test('when the ID is provided', () => {
-    const html = createTrackingSnippet({
-      trackingUrl: 'alexlafroscia.com',
-      siteId: 'foo-bar'
+  describe('when the tracking URL is not provided', () => {
+    test('defaulting to the CDN URL', () => {
+      const html = createTrackingSnippet({
+        siteId: 'foo-bar'
+      })
+
+      expect(html).toContain('//cdn.usefathom.com/tracker.js')
     })
 
-    expect(html).toContain("fathom('set', 'siteId', 'foo-bar')")
+    test('ensuring that a tracking ID is provided', () => {
+      expect(function() {
+        createTrackingSnippet({})
+      }).toThrow()
+    })
+  })
+
+  describe('setting the site ID', () => {
+    test('when the ID is not provided', () => {
+      const html = createTrackingSnippet({
+        trackingUrl: 'alexlafroscia.com'
+      })
+
+      expect(html).not.toContain("fathom('set', 'siteId'")
+    })
+
+    test('when the ID is provided', () => {
+      const html = createTrackingSnippet({
+        trackingUrl: 'alexlafroscia.com',
+        siteId: 'foo-bar'
+      })
+
+      expect(html).toContain("fathom('set', 'siteId', 'foo-bar')")
+    })
+  })
+})
+
+describe('isExcludedHostname', () => {
+  test('ensuring excluded hostnames is an array', () => {
+    expect(function() {
+      isExcludedHostname({})
+    }).toThrow()
+  })
+
+  test('when hostname is excluded', () => {
+    const isExcluded = isExcludedHostname(['localhost'], 'localhost')
+    expect(isExcluded).toBe(true)
+  })
+
+  test('when hostname is not excluded', () => {
+    const isExcluded = isExcludedHostname(['localhost'], 'localghost')
+    expect(isExcluded).toBe(false)
   })
 })

--- a/src/gatsby-browser.js
+++ b/src/gatsby-browser.js
@@ -1,5 +1,11 @@
-exports.onRouteUpdate = ({ location }) => {
-  if (process.env.NODE_ENV === 'production' && typeof fathom !== 'undefined') {
+import { isExcludedHostname } from './utils'
+
+exports.onRouteUpdate = ({ location }, { excludeHostnames }) => {
+  if (
+    process.env.NODE_ENV === 'production' &&
+    typeof fathom !== 'undefined' &&
+    !isExcludedHostname(excludeHostnames, location.hostname)
+  ) {
     fathom('trackPageview')
   }
 }

--- a/src/gatsby-browser.js
+++ b/src/gatsby-browser.js
@@ -1,10 +1,10 @@
-import { isExcludedHostname } from './utils'
+import { isWhitelistedHostname } from './utils'
 
-exports.onRouteUpdate = ({ location }, { excludeHostnames }) => {
+exports.onRouteUpdate = ({ location }, { whitelistHostnames }) => {
   if (
     process.env.NODE_ENV === 'production' &&
     typeof fathom !== 'undefined' &&
-    !isExcludedHostname(excludeHostnames, location.hostname)
+    isWhitelistedHostname(whitelistHostnames, location.hostname)
   ) {
     fathom('trackPageview')
   }

--- a/src/utils.js
+++ b/src/utils.js
@@ -23,3 +23,14 @@ exports.createTrackingSnippet = function createTrackingSnippet({
     ${siteId && "fathom('set', 'siteId', '" + siteId + "');"}
   `
 }
+
+exports.isExcludedHostname = function isExcludedHostname(
+  excludeHostnames = [],
+  hostname
+) {
+  if (!Array.isArray(excludeHostnames)) {
+    throw new Error('`excludeHostnames` must be provided as an array')
+  }
+
+  return excludeHostnames.indexOf(hostname) !== -1
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -24,13 +24,17 @@ exports.createTrackingSnippet = function createTrackingSnippet({
   `
 }
 
-exports.isExcludedHostname = function isExcludedHostname(
-  excludeHostnames = [],
+exports.isWhitelistedHostname = function isWhitelistedHostname(
+  whitelist = [],
   hostname
 ) {
-  if (!Array.isArray(excludeHostnames)) {
-    throw new Error('`excludeHostnames` must be provided as an array')
+  if (!Array.isArray(whitelist)) {
+    throw new Error('`whitelistHostnames` must be provided as an array')
   }
 
-  return excludeHostnames.indexOf(hostname) !== -1
+  if (whitelist.length === 0) {
+    return true
+  }
+
+  return whitelist.indexOf(hostname) !== -1
 }


### PR DESCRIPTION
Refers to Issue https://github.com/lgraubner/gatsby-plugin-fathom/issues/10

Adds functionality to ignore specific hostnames from firing track events.

```
    {
      resolve: 'gatsby-plugin-fathom',
      options: {
        whitelistHostnames: [
          'yoursite.com'
        ]
      }
    }
```