### PR TITLE
Add subdomain to whitelist

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ module.exports = {
         siteId: 'FATHOM_SITE_ID',
         // Domain whitelist
         whitelistHostnames: [
-          'yoursite.com'
+          'yoursite.com',
+          'www.yoursite.com'
         ]
       }
     }


### PR DESCRIPTION
I incorrectly assumed adding `mydomain.com` to the whitelist would automatically whitelist sub-domains. This pr adds an extra example to the docs to make it clearer that sub-domains need to be explicitly defined.