### PR TITLE
fix useGoal breaking server-side rendering

### DIFF
--- a/src/use-goal.js
+++ b/src/use-goal.js
@@ -1,6 +1,6 @@
 export default function useGoal(id, debug = false) {
   return () => {
-    if (window.fathom === undefined) {
+    if (typeof window === 'undefined' || typeof window.fathom === 'undefined') {
       return
     }
 


### PR DESCRIPTION
Using 1.3.0 in Gatsby I get this when creating a production build:

```
10:21:47 AM: failed Building static HTML for pages - 2.575s
10:21:47 AM: error "window" is not available during server side rendering.
10:21:47 AM: 
10:21:47 AM:   11 |   var debug = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : false;
10:21:47 AM:   12 |   return function () {
10:21:47 AM: > 13 |     if (window.fathom === undefined) {
10:21:47 AM:      |     ^
10:21:47 AM:   14 |       return;
10:21:47 AM:   15 |     }
10:21:47 AM:   16 | 
10:21:47 AM: 
10:21:47 AM:   WebpackError: ReferenceError: window is not defined
```

This PR fixes this.